### PR TITLE
List Yarn as a dependency for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You'll need these things to build the project:
 
  - Python 3
  - Ninja
+ - Yarn (only when building for iOS)
  - Meson (`pip install meson`)
  - Clang and LLD (on mac, `brew install llvm`, on linux, `sudo apt install clang lld` or `sudo pacman -S clang lld` or whatever)
 


### PR DESCRIPTION
I'm trying to build this and realized it needs Yarn to build, which is not something that I have installed. I thought it might be useful to list this as a build requirement to help those like me who don't have it.

Anyways, onto figuring out how to tell deasync to target iOS instead of x86_64 through gyp…