### PR TITLE
sys_setitimer fixes for OpenSSL

### DIFF
--- a/kernel/time.c
+++ b/kernel/time.c
@@ -65,12 +65,8 @@ dword_t sys_setitimer(dword_t which, addr_t new_val_addr, addr_t old_val_addr) {
 
     struct timer_spec spec;
     
-    if (val.value.sec && !val.value.usec) {
-        val.value.usec = val.value.sec * 1000;
-    }
     if (!val.interval.sec && !val.interval.usec) {
-        val.interval.sec = val.value.sec;
-        val.interval.usec = val.value.usec;
+        val.interval.sec = 1;
     }
     spec.interval.tv_sec = val.interval.sec;
     spec.interval.tv_nsec = val.interval.usec * 1000;

--- a/kernel/time.c
+++ b/kernel/time.c
@@ -64,6 +64,14 @@ dword_t sys_setitimer(dword_t which, addr_t new_val_addr, addr_t old_val_addr) {
     }
 
     struct timer_spec spec;
+    
+    if (val.value.sec && !val.value.usec) {
+        val.value.usec = val.value.sec * 1000;
+    }
+    if (!val.interval.sec && !val.interval.usec) {
+        val.interval.sec = val.value.sec;
+        val.interval.usec = val.value.usec;
+    }
     spec.interval.tv_sec = val.interval.sec;
     spec.interval.tv_nsec = val.interval.usec * 1000;
     spec.value.tv_sec = val.value.sec;

--- a/kernel/time.c
+++ b/kernel/time.c
@@ -121,8 +121,10 @@ dword_t sys_times(addr_t tbuf) {
     if (tbuf) {
         struct tms_ tmp;
         struct rusage_ rusage = rusage_get_current();
-        tmp.tms_utime = rusage.utime.usec * (CLOCKS_PER_SEC/1000);
-        tmp.tms_stime = rusage.stime.usec * (CLOCKS_PER_SEC/1000);
+        tmp.tms_utime = (rusage.utime.sec * 100) + (rusage.utime.usec/10000);
+        tmp.tms_stime = (rusage.utime.sec * 100) + (rusage.utime.usec/10000);
+        tmp.tms_cutime = tmp.tms_utime;
+        tmp.tms_cstime = tmp.tms_stime;
         if (user_put(tbuf, tmp))
             return _EFAULT;
     }

--- a/util/timer.h
+++ b/util/timer.h
@@ -38,7 +38,7 @@ static inline bool timespec_is_zero(struct timespec ts) {
 }
 
 static inline bool timespec_positive(struct timespec ts) {
-    return ts.tv_sec > 0 && ts.tv_nsec > 0;
+    return ts.tv_sec > 0 || (ts.tv_sec == 0 && ts.tv_nsec > 0);
 }
 
 typedef void (*timer_callback_t)(void *data);


### PR DESCRIPTION
OpenSSL's speed kinda runs now, but some more times() fixes are needed to have a sane result