### PR TITLE
Implement gettimeofday

### DIFF
--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -52,6 +52,7 @@ syscall_t syscall_table[] = {
     [75]  = (syscall_t) sys_setrlimit,
     [76]  = (syscall_t) sys_getrlimit,
     [77]  = (syscall_t) sys_getrusage,
+    [78]  = (syscall_t) sys_gettimeofday,
     [83]  = (syscall_t) sys_symlink,
     [85]  = (syscall_t) sys_readlink,
     [90]  = (syscall_t) sys_mmap,

--- a/kernel/time.h
+++ b/kernel/time.h
@@ -15,6 +15,10 @@ struct timespec_ {
     dword_t sec;
     dword_t nsec;
 };
+struct timezone_ {
+    dword_t minuteswest;
+    dword_t dsttime;
+};
 
 #define ITIMER_REAL_ 0
 #define ITIMER_VIRTUAL_ 1
@@ -35,5 +39,6 @@ dword_t sys_getitimer(dword_t which, addr_t val);
 dword_t sys_setitimer(dword_t which, addr_t new_val, addr_t old_val);
 dword_t sys_times( addr_t tbuf);
 dword_t sys_nanosleep(addr_t req, addr_t rem);
+dword_t sys_gettimeofday(addr_t tv, addr_t tz);
 
 #endif


### PR DESCRIPTION
I wanted to poke around the internals of iSH, so I thought I'd "get my feet wet" by implementing a simple, obsolete, and mostly useless system call to get a taste of project development. Please let me know if there's anything you'd like changed; I've tried to model this after the other syscall implementations.

Just as a heads up, since this confused me for a while: if you want to test this, you'll need to use `syscall(SYS_gettimeofday, …)` directly instead of `gettimeofday` because musl's version just calls `clock_gettime`.