### PR TITLE
Make Xcode happy

### DIFF
--- a/fs/fd.h
+++ b/fs/fd.h
@@ -87,7 +87,7 @@ struct fdtable {
     bits_t *cloexec;
 };
 
-struct fdtable *fdtable_new();
+struct fdtable *fdtable_new(unsigned size);
 void fdtable_release(struct fdtable *table);
 int fdtable_resize(struct fdtable *table, unsigned size);
 struct fdtable *fdtable_copy(struct fdtable *table);

--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 				BB792B7D1F96E32B00FFB7A4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		BB792B511F96D90D00FFB7A4 /* Products */ = {
 			isa = PBXGroup;

--- a/kernel/errno.h
+++ b/kernel/errno.h
@@ -114,6 +114,6 @@
 
 
 int err_map(int err);
-int errno_map();
+int errno_map(void);
 
 #endif

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -15,7 +15,7 @@ struct fs_info {
     struct fd *root;
     lock_t lock;
 };
-struct fs_info *fs_info_new();
+struct fs_info *fs_info_new(void);
 struct fs_info *fs_info_copy(struct fs_info *fs);
 void fs_info_release(struct fs_info *fs);
 

--- a/kernel/resource.h
+++ b/kernel/resource.h
@@ -53,7 +53,7 @@ struct rusage_ {
     dword_t nivcsw;
 };
 
-struct rusage_ rusage_get_current();
+struct rusage_ rusage_get_current(void);
 void rusage_add(struct rusage_ *dst, struct rusage_ *src);
 #define RUSAGE_SELF_ 0
 #define RUSAGE_CHILDREN_ -1

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -69,7 +69,7 @@ struct sighand {
     bool on_altstack;
     lock_t lock;
 };
-struct sighand *sighand_new();
+struct sighand *sighand_new(void);
 struct sighand *sighand_copy(struct sighand *sighand);
 void sighand_release(struct sighand *sighand);
 


### PR DESCRIPTION
Use `(void)` instead of `()` for function prototypes, except for `fdtable_new` which actually takes an `unsigned`. Also, tell Xcode that this project uses spaces for indentation–if you don't, mine will keep trying to insert tabs everywhere because that's what my global configuration is set to.