### PR TITLE
log: call NSLog instead of NSLogv

### DIFF
--- a/kernel/log.c
+++ b/kernel/log.c
@@ -156,8 +156,8 @@ static void log_line(const char *line) {
 }
 #elif LOG_HANDLER_NSLOG
 static void log_line(const char *line) {
-    extern void NSLogv(CFStringRef msg, va_list args);
-    NSLogv(CFSTR("%s"), line);
+    extern void NSLog(CFStringRef msg, ...);
+    NSLog(CFSTR("%s"), line);
 }
 #endif
 


### PR DESCRIPTION
Giving NSLogv a char* instead of a va_list crashes on iPad Air.
Switch to regular NSLog instead.

----

Why was NSLogv used here instead of NSLog? Is there something on macOS that prevents using regular NSLog?