### PR TITLE
decode: handle GS prefix after LOCK prefix

### DIFF
--- a/emu/decode.h
+++ b/emu/decode.h
@@ -648,8 +648,10 @@ restart:
 
         // lock
         case 0xf0:
+            lockrestart:
             READINSN;
             switch (insn) {
+                case 0x65: TRACE("segment gs\n"); SEG_GS(); goto lockrestart;
 
 #define MAKE_OP_ATOMIC(x, OP, op) \
         case x+0x0: TRACEI("lock " op " reg8, modrm8"); \


### PR DESCRIPTION
This fixes application startup on Ubuntu. #107

----

This, along with [a hack](https://github.com/zhuowei/ish/commit/b99dfb26c1a6afbfd401e05c045b8426e73c2e3a) to make all unimplemented syscalls return _ENOSYS, is enough to start Ubuntu's /bin/bash.

![screen shot 2018-11-17 at 6 14 30 pm](https://user-images.githubusercontent.com/704768/48667888-b905ec80-ea95-11e8-9b3e-93501309cf7f.png)

Some questions:

1. I tried to model this after the regular GS handling code. Is the goto correct? It should restart decoding on the next prefix.
2. I think switching the order of these prefixes is [technically allowed](https://stackoverflow.com/questions/7197282/order-for-encoding-x86-instruction-prefix-bytes); are there any apps in the wild that has the GS prefix before LOCK?
3. Not related to this change, but : why do unimplemented syscalls raise a signal? Linux itself just [returns _ENOSYS](https://github.com/torvalds/linux/blob/master/kernel/sys_ni.c#L17). I understand that noting which apps use unimplemented syscalls is important, but shouldn't there be an option to ignore missing syscalls to get more apps to run?