### PR TITLE
decode: add fpu instructions needed by ffmpeg

### DIFF
--- a/emu/decode.h
+++ b/emu/decode.h
@@ -555,6 +555,7 @@ restart:
                     case 0xd80: TRACE("fadd mem32"); FADDM(mem_addr_real,32); break;
                     case 0xd81: TRACE("fmul mem32"); FMULM(mem_addr_real,32); break;
                     case 0xd84: TRACE("fsub mem32"); FSUBM(mem_addr_real,32); break;
+                    case 0xd85: TRACE("fsubr mem32"); FSUBRM(mem_addr_real,32); break;
                     case 0xd86: TRACE("fdiv mem32"); FDIVM(mem_addr_real,32); break;
                     case 0xd87: TRACE("fdivr mem32"); FDIVRM(mem_addr_real,32); break;
                     case 0xd90: TRACE("fld mem32"); FLDM(mem_addr_real,32); break;
@@ -583,6 +584,8 @@ restart:
                     case 0xdc7: TRACE("fdivr mem64"); FDIVRM(mem_addr_real,64); break;
                     case 0xdd2: TRACE("fst mem64"); FSTM(mem_addr_real,64); break;
                     case 0xdd3: TRACE("fstp mem64"); FSTM(mem_addr_real,64); FPOP; break;
+                    case 0xde1: TRACE("fimuls mem16"); FIMUL(mem_addr,16); break;
+                    case 0xde7: TRACE("fidivrs mem16"); FIDIVR(mem_addr,16); break;
                     case 0xdf0: TRACE("fild mem16"); FILD(mem_addr,16); break;
                     case 0xdf5: TRACE("fild mem64"); FILD(mem_addr,64); break;
                     case 0xdf7: TRACE("fistp mem64"); FIST(mem_addr,64); FPOP; break;
@@ -594,6 +597,8 @@ restart:
                     case 0xd81: TRACE("fmul st(i), st"); FMUL(st_i, st_0); break;
                     case 0xd84: TRACE("fsub st(i), st"); FSUB(st_i, st_0); break;
                     case 0xd85: TRACE("fsubr st(i), st"); FSUBR(st_i, st_0); break;
+                    case 0xd86: TRACE("fdiv st(i), st"); FDIV(st_i, st_0); break;
+                    case 0xd87: TRACE("fdivr st(i), st"); FDIVR(st_i, st_0); break;
                     case 0xd90: TRACE("fld st(i)"); FLD(); break;
                     case 0xd91: TRACE("fxch st"); FXCH(); break;
                     case 0xdb5: TRACE("fucomi st"); FUCOMI(); break;
@@ -626,6 +631,7 @@ restart:
                     case 0xd956: TRACE("fldz"); FLDC(zero); break;
                     case 0xd960: TRACE("f2xm1"); F2XM1(); break;
                     case 0xd961: TRACE("fyl2x"); FYL2X(); break;
+                    case 0xd963: TRACE("fpatan"); FPATAN(); break;
                     case 0xd970: TRACE("fprem"); FPREM(); break;
                     case 0xd972: TRACE("fsqrt"); FSQRT(); break;
                     case 0xd974: TRACE("frndint"); FRNDINT(); break;

--- a/emu/fpu.c
+++ b/emu/fpu.c
@@ -239,3 +239,9 @@ void fpu_ldcw16(struct cpu_state *cpu, uint16_t *i) {
     cpu->fcw = *i;
     f80_rounding_mode = cpu->rc;
 }
+
+void fpu_patan(struct cpu_state *cpu) {
+    // there's no native atan2 for 80-bit float yet.
+    ST(1) = f80_from_double(atan2(f80_to_double(ST(1)), f80_to_double(ST(0))));
+    fpu_pop(cpu);
+}

--- a/emu/fpu.h
+++ b/emu/fpu.h
@@ -92,5 +92,6 @@ void fpu_divrm64(struct cpu_state *cpu, double *f);
 
 void fpu_stcw16(struct cpu_state *cpu, uint16_t *i);
 void fpu_ldcw16(struct cpu_state *cpu, uint16_t *i);
+void fpu_patan(struct cpu_state *cpu);
 
 #endif

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -402,6 +402,7 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
 #define FDIVR(src, dst) hhh(fpu_divr, src, dst)
 #define FIDIVR(val,z) h_read(fpu_idivr, z)
 #define FDIVRM(val,z) h_read(fpu_divrm, z)
+#define FPATAN() h(fpu_patan)
 
 #define DECODER_RET int
 #define DECODER_NAME gen_step


### PR DESCRIPTION
The list of added instructions:

- fsubr mem32
- fimuls mem16
- fidivrs mem16
- fdiv st(i), st
- fdivr st(i), st
- fpatan

fpatan's implementation calls down to normal atan2 since I don't know how to implement a 80-bit atan2.

This allows ffmpeg to start and convert 2 minutes of a .m4a file to WAV before segfaulting.

----

See #71.

I don't have testcases for the new instructions yet - how are you currently testing the FPU instructions?