### PR TITLE
Make copy/arrow keys/escape/a bunch of other stuff work again

### DIFF
--- a/app/TerminalView.m
+++ b/app/TerminalView.m
@@ -117,12 +117,6 @@ typedef enum {
     [self.terminal sendInput:data.bytes length:data.length];
 }
 
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-    if (action == @selector(paste:))
-        return YES;
-    return NO;
-}
-
 - (void)paste:(id)sender {
     NSString *string = UIPasteboard.generalPasteboard.string;
     if (string) {


### PR DESCRIPTION
The current `-[TerminalView canPerformAction:withSender:]` breaks a bunch of things because it returns `NO` for a bunch of commands we can actually handle, such as copying or `handleKeyEquivalent:`.