### PR TITLE
decode: implement fcomi

### DIFF
--- a/emu/decode.h
+++ b/emu/decode.h
@@ -620,6 +620,7 @@ restart:
                     case 0xd90: TRACE("fld st(i)"); FLD(); break;
                     case 0xd91: TRACE("fxch st"); FXCH(); break;
                     case 0xdb5: TRACE("fucomi st"); FUCOMI(); break;
+                    case 0xdb6: TRACE("fcomi st"); FCOMI(); break;
                     case 0xdc0: TRACE("fadd st, st(i)"); FADD(st_0, st_i); break;
                     case 0xdc1: TRACE("fmul st, st(i)"); FMUL(st_0, st_i); break;
                     case 0xdc4: TRACE("fsubr st, st(i)"); FSUBR(st_0, st_i); break;

--- a/emu/interp/fpu.h
+++ b/emu/interp/fpu.h
@@ -90,6 +90,9 @@
     cpu->pf = 0; cpu->pf_res = 0
 // not worrying about nans and shit yet
 
+#define FCOMI FUCOMI
+// FCOMI is supposed to be even more strict with NaNs. We still won't worry.
+
 #define F_COMPARE(x) \
     cpu->c0 = f80_lt(ST(0), x); \
     cpu->c1 = 0; \

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -372,6 +372,7 @@ void helper_rdtsc(struct cpu_state *cpu);
 #define FCOMM(val,z) h_read(fpu_comm, z)
 #define FUCOM() hh(fpu_ucom, st_i)
 #define FUCOMI() hh(fpu_ucomi, st_i)
+#define FCOMI() hh(fpu_comi, st_i)
 #define FST() hh(fpu_st, st_i)
 #define FCHS() h(fpu_chs)
 #define FABS() h(fpu_abs)


### PR DESCRIPTION
It's just aliased to fucomi for now.
This fixes launching apt in a Ubuntu 18.04.1 root fs.