### PR TITLE
decode: implement fxam

### DIFF
--- a/emu/decode.h
+++ b/emu/decode.h
@@ -641,6 +641,7 @@ restart:
                     default: switch (insn << 8 | modrm.opcode << 4 | modrm.rm_opcode) {
                     case 0xd940: TRACE("fchs"); FCHS(); break;
                     case 0xd941: TRACE("fabs"); FABS(); break;
+                    case 0xd945: TRACE("fxam"); FXAM(); break;
                     case 0xd950: TRACE("fld1"); FLDC(one); break;
                     case 0xd951: TRACE("fldl2t"); FLDC(log2t); break;
                     case 0xd952: TRACE("fldl2e"); FLDC(log2e); break;

--- a/emu/float80.c
+++ b/emu/float80.c
@@ -89,7 +89,7 @@ static float80 f80_shift_right(float80 f, int shift) {
 // a number is unsupported if the cursed bit (first bit of the significand,
 // also known as the integer bit) is incorrect. it must be 0 for denormals and
 // 1 for any other type of number.
-static bool f80_is_supported(float80 f) {
+bool f80_is_supported(float80 f) {
     if (f.exp == EXP_DENORMAL)
         return f.signif >> 63 == 0;
     return f.signif >> 63 == 1;
@@ -101,8 +101,11 @@ bool f80_isnan(float80 f) {
 bool f80_isinf(float80 f) {
     return f.exp == EXP_SPECIAL && (f.signif & (-1ul >> 1)) == 0;
 }
-static bool f80_iszero(float80 f) {
+bool f80_iszero(float80 f) {
     return f.exp == EXP_DENORMAL && f.signif == 0;
+}
+bool f80_isdenormal(float80 f) {
+    return f.exp == EXP_DENORMAL && f.signif != 0;
 }
 
 static float80 f80_normalize(float80 f) {

--- a/emu/float80.h
+++ b/emu/float80.h
@@ -22,6 +22,9 @@ double f80_to_double(float80 f);
 
 bool f80_isnan(float80 f);
 bool f80_isinf(float80 f);
+bool f80_iszero(float80 f);
+bool f80_isdenormal(float80 f);
+bool f80_is_supported(float80 f);
 
 float80 f80_neg(float80 f);
 float80 f80_abs(float80 f);

--- a/emu/fpu.c
+++ b/emu/fpu.c
@@ -245,3 +245,27 @@ void fpu_patan(struct cpu_state *cpu) {
     ST(1) = f80_from_double(atan2(f80_to_double(ST(1)), f80_to_double(ST(0))));
     fpu_pop(cpu);
 }
+
+void fpu_xam(struct cpu_state *cpu) {
+    float80 f = ST(0);
+    int outflags = 0;
+    if (!f80_is_supported(f)) {
+        outflags = 0b000;
+    } else if (f80_isnan(f)) {
+        outflags = 0b001;
+    } else if (f80_isinf(f)) {
+        outflags = 0b011;
+    } else if (f80_iszero(f)) {
+        outflags = 0b100;
+    } else if (f80_isdenormal(f)) {
+        outflags = 0b110;
+    } else {
+        // normal.
+        // todo: empty
+        outflags = 0b010;
+    }
+    cpu->c1 = f.sign;
+    cpu->c0 = outflags & 1;
+    cpu->c2 = (outflags >> 1) & 1;
+    cpu->c3 = (outflags >> 2) & 1;
+}

--- a/emu/fpu.h
+++ b/emu/fpu.h
@@ -93,5 +93,6 @@ void fpu_divrm64(struct cpu_state *cpu, double *f);
 void fpu_stcw16(struct cpu_state *cpu, uint16_t *i);
 void fpu_ldcw16(struct cpu_state *cpu, uint16_t *i);
 void fpu_patan(struct cpu_state *cpu);
+void fpu_xam(struct cpu_state *cpu);
 
 #endif

--- a/emu/interp/fpu.h
+++ b/emu/interp/fpu.h
@@ -128,3 +128,5 @@
 #define FPATAN() \
     ST(1) = f80_from_double(atan2(f80_to_double(ST(1)), f80_to_double(ST(0)))); \
     FPOP
+
+#define FXAM() UNDEFINED

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -405,6 +405,7 @@ void helper_rdtsc(struct cpu_state *cpu);
 #define FIDIVR(val,z) h_read(fpu_idivr, z)
 #define FDIVRM(val,z) h_read(fpu_divrm, z)
 #define FPATAN() h(fpu_patan)
+#define FXAM() h(fpu_xam)
 
 #define DECODER_RET int
 #define DECODER_NAME gen_step


### PR DESCRIPTION
There's no interpreter version yet.

----

This fixes the illegal instruction error when running `apt update` in a Ubuntu rootfs.

I haven't tested if this is accurate. `apt update` runs this instruction to show download progress. Since `select` with more than one fd doesn't work, it's stuck at 0%, so I can't tell if the instruction is broken.