### PR TITLE
reorganize device initialization for mem devs

### DIFF
--- a/fs/dev.c
+++ b/fs/dev.c
@@ -1,6 +1,7 @@
 #include "kernel/errno.h"
 #include "fs/fd.h"
 #include "fs/dev.h"
+#include "fs/mem.h"
 #include "fs/tty.h"
 
 #pragma GCC diagnostic ignored "-Winitializer-overrides"
@@ -9,7 +10,7 @@ struct dev_ops *block_devs[] = {
 };
 struct dev_ops *char_devs[] = {
     [0 ... 255] = NULL,
-    [1] = &null_dev,
+    [1] = &mem_dev,
     [4] = &tty_dev,
 };
 
@@ -22,22 +23,3 @@ int dev_open(int major, int minor, int type, struct fd *fd) {
         return 0;
     return dev->open(major, minor, type, fd);
 }
-
-// this device seemed so simple it was hardly worth making a new file for it
-
-static int null_open(int major, int minor, int type, struct fd *fd) {
-    if (minor != 3)
-        return _ENXIO;
-    return 0;
-}
-static ssize_t null_read(struct fd *fd, void *buf, size_t bufsize) {
-    return 0;
-}
-static ssize_t null_write(struct fd *fd, const void *buf, size_t bufsize) {
-    return bufsize;
-}
-struct dev_ops null_dev = {
-    .open = null_open,
-    .fd.read = null_read,
-    .fd.write = null_write,
-};

--- a/fs/mem.c
+++ b/fs/mem.c
@@ -1,0 +1,35 @@
+#include "kernel/errno.h"
+#include "fs/mem.h"
+#include "fs/null.h"
+
+// this file handles major device number 1, minor device numbers are mapped in table below
+#pragma GCC diagnostic ignored "-Winitializer-overrides"
+struct dev_ops *mem_devs[] = {
+    [0 ... 255] = NULL,
+    // [1] = &prog_mem_dev,
+    // [2] = &kmem_dev, // (not really applicable)
+    [3] = &null_dev,
+    // [4] = &port_dev,
+    // [5] = &zero_dev,
+    // [7] = &full_dev,
+    // [8] = &random_dev,
+    // [9] = &random_dev,
+    // [10] = &aio_dev,
+    // [11] = &kmsg_dev,
+    // [12] = &oldmem_dev, // replaced by /proc/vmcore
+};   
+
+static int mem_open(int major, int minor, int type, struct fd *fd) {
+    struct dev_ops *dev = mem_devs[minor];
+    if (dev == NULL) {
+        return _ENXIO;
+    }
+    fd->ops = &dev->fd;
+    if (!dev->open)
+        return 0;
+    return dev->open(major, minor, type, fd);
+}
+
+struct dev_ops mem_dev = {
+    .open = mem_open,
+};

--- a/fs/mem.h
+++ b/fs/mem.h
@@ -1,0 +1,9 @@
+#ifndef FS_NULL_H
+#define FS_NULL_H
+
+#include "kernel/fs.h"
+#include "fs/dev.h"
+
+extern struct dev_ops mem_dev;
+
+#endif

--- a/fs/null.c
+++ b/fs/null.c
@@ -1,0 +1,20 @@
+#include "kernel/errno.h"
+#include "fs/null.h"
+
+static int null_open(int major, int minor, int type, struct fd *fd) {
+    return 0;
+}   
+
+static ssize_t null_read(struct fd *fd, void *buf, size_t bufsize) {
+    return 0;
+}   
+
+static ssize_t null_write(struct fd *fd, const void *buf, size_t bufsize) {
+    return bufsize;
+}   
+
+struct dev_ops null_dev = {
+    .open = null_open,
+    .fd.read = null_read,
+    .fd.write = null_write,
+};  

--- a/fs/null.h
+++ b/fs/null.h
@@ -1,0 +1,9 @@
+#ifndef FS_NULL_H
+#define FS_NULL_H
+
+#include "kernel/fs.h"
+#include "fs/dev.h"
+
+extern struct dev_ops null_dev;
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,8 @@ src = [
     'fs/pipe.c',
 
     'fs/dev.c',
+    'fs/mem.c',
+    'fs/null.c',
     'fs/tty.c',
     'fs/tty-real.c',
 


### PR DESCRIPTION
I was going to implement /dev/random, but it seems like the best option is to proxy to the real file and I didn't want to dig into your fd mapping and flags stuff, so here's the cleanup I did to prep for it.