### PR TITLE
Update uname to reflect current version

### DIFF
--- a/kernel/uname.c
+++ b/kernel/uname.c
@@ -14,7 +14,7 @@ void do_uname(struct uname *uts) {
     memset(uts, 0, sizeof(struct uname));
     strcpy(uts->system, "Linux");
     strcpy(uts->hostname, real_uname.nodename);
-    strcpy(uts->release, "3.2.0-ish");
+    strcpy(uts->release, "3.8.0-ish");
     strcpy(uts->version, "SUPER AWESOME compiled on " __DATE__ );
     strcpy(uts->arch, "i686");
     strcpy(uts->domain, "(none)");


### PR DESCRIPTION
We're not on 3.2.0 anymore, so this should be changed to avoid confusion
I was actually confused when I did uname -a on iSH and knew it was based on 3.8.0, this should fix it