### PR TITLE
If stdout isn't a tty either, fall back to stdio

### DIFF
--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -93,7 +93,7 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     if (err < 0)
         return err;
     tty_drivers[TTY_CONSOLE_MAJOR] = &real_tty_driver;
-    if (isatty(STDIN_FILENO)) {
+    if (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO)) {
         err = create_stdio(console);
         if (err < 0)
             return err;


### PR DESCRIPTION
Should this check be done for stderr too? 