### PR TITLE
WIP: Default theme based on iOS 13 Dark/Light mode

### DIFF
--- a/app/Assets.xcassets/systemBackgroundColor.colorset/Contents.json
+++ b/app/Assets.xcassets/systemBackgroundColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000"
+        }
+      }
+    }
+  ]
+}

--- a/app/Assets.xcassets/systemForegroundColor.colorset/Contents.json
+++ b/app/Assets.xcassets/systemForegroundColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/app/UserPreferences.h
+++ b/app/UserPreferences.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSString *> *)presetNames;
 - (NSString *)presetName;
 
-@property (nonatomic, readonly) NSNumber *identifier;
+@property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) UIColor *foregroundColor;
 @property (nonatomic, readonly) UIColor *backgroundColor;
 
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) UIStatusBarStyle statusBarStyle;
 
 @end
-extern NSString *const kThemeIdentifier;
+extern NSString *const kThemeName;
 extern NSString *const kThemeForegroundColor;
 extern NSString *const kThemeBackgroundColor;
 

--- a/app/UserPreferences.h
+++ b/app/UserPreferences.h
@@ -24,12 +24,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSString *> *)presetNames;
 - (NSString *)presetName;
 
+@property (nonatomic, readonly) NSNumber *identifier;
 @property (nonatomic, readonly) UIColor *foregroundColor;
 @property (nonatomic, readonly) UIColor *backgroundColor;
+
 @property (readonly) UIKeyboardAppearance keyboardAppearance;
 @property (readonly) UIStatusBarStyle statusBarStyle;
 
 @end
+extern NSString *const kThemeIdentifier;
 extern NSString *const kThemeForegroundColor;
 extern NSString *const kThemeBackgroundColor;
 

--- a/app/UserPreferences.m
+++ b/app/UserPreferences.m
@@ -68,8 +68,8 @@ static NSString *const kPreferenceBootEnabledKey = @"Boot Enabled";
     [_defaults setObject:fontSize forKey:kPreferenceFontSizeKey];
 }
 
-- (NSNumber *)identifier {
-    return self.theme.identifier;
+- (NSString *)name {
+    return self.theme.name;
 }
 - (UIColor *)foregroundColor {
     return self.theme.foregroundColor;
@@ -136,15 +136,15 @@ static UIColor *UnarchiveColor(id data) {
     if (self = [super init]) {
         _foregroundColor = UnarchiveColor(props[kThemeForegroundColor]);
         _backgroundColor = UnarchiveColor(props[kThemeBackgroundColor]);
-        _identifier = props[kThemeIdentifier];
+        _name = props[kThemeName];
     }
     return self;
 }
 
-+ (instancetype)_themeWithForegroundColor:(UIColor *)foreground backgroundColor:(UIColor *)background identifier:(NSNumber *)identifier {
++ (instancetype)_themeWithForegroundColor:(UIColor *)foreground backgroundColor:(UIColor *)background name:(NSString *)name {
     return [[self alloc] initWithProperties:@{kThemeForegroundColor: ArchiveColor(foreground),
                                               kThemeBackgroundColor: ArchiveColor(background),
-                                              kThemeIdentifier: identifier
+                                              kThemeName: name
                                               }];
 }
 
@@ -169,7 +169,7 @@ static UIColor *UnarchiveColor(id data) {
 - (NSDictionary<NSString *,id> *)properties {
     return @{kThemeForegroundColor: ArchiveColor(self.foregroundColor),
              kThemeBackgroundColor: ArchiveColor(self.backgroundColor),
-             kThemeIdentifier: self.identifier};
+             kThemeName: self.name};
 }
 
 - (BOOL)isEqual:(id)object {
@@ -182,16 +182,16 @@ NSDictionary<NSString *, Theme *> *presetThemes;
 + (void)initialize {
     presetThemes = @{@"System": [self _themeWithForegroundColor:[UIColor colorNamed:@"systemForegroundColor"]
                                                 backgroundColor:[UIColor colorNamed:@"systemBackgroundColor"]
-                                                     identifier:@0],
+                                                           name:@"System"],
                      @"Light":  [self _themeWithForegroundColor:UIColor.blackColor
                                                 backgroundColor:UIColor.whiteColor
-                                                     identifier:@1],
+                                                           name:@"Light"],
                      @"Dark":   [self _themeWithForegroundColor:UIColor.whiteColor
                                                 backgroundColor:UIColor.blackColor
-                                                     identifier:@2],
+                                                           name:@"Dark"],
                      @"1337":   [self _themeWithForegroundColor:UIColor.greenColor
                                                 backgroundColor:UIColor.blackColor
-                                                     identifier:@3]};
+                                                           name:@"1337"]};
 }
 
 + (NSArray<NSString *> *)presetNames {
@@ -216,6 +216,6 @@ NSDictionary<NSString *, Theme *> *presetThemes;
 
 @end
 
-NSString *const kThemeIdentifier = @"ThemeIdentifier";
+NSString *const kThemeName = @"ThemeIdentifier";
 NSString *const kThemeForegroundColor = @"ForegroundColor";
 NSString *const kThemeBackgroundColor = @"BackgroundColor";


### PR DESCRIPTION
Added default theme which inherits system color scheme (i.e. Light mode and dark mode) when running iOS 13 or higher