### PR TITLE
Fix FUNDING.yml PayPal link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 patreon: tbodt
-paypal: https://www.paypal.me/tbodt
+custom: https://www.paypal.me/tbodt


### PR DESCRIPTION
'paypal' is not a valid funding platform, so I guess it should just be a custom link.