### PR TITLE
Implement return cache optimization.

### DIFF
--- a/jit/frame.h
+++ b/jit/frame.h
@@ -1,9 +1,14 @@
 #include "emu/cpu.h"
 
+// keep in sync with asm
+#define JIT_RETURN_CACHE_SIZE 65536
+#define JIT_RETURN_CACHE_HASH(x) ((x) & 0xFFFF)
+
 struct jit_frame {
     struct cpu_state cpu;
     void *bp;
     addr_t value_addr;
     uint64_t value[2]; // buffer for crosspage crap
     struct jit_block *last_block;
+    long ret_cache[JIT_RETURN_CACHE_SIZE];
 };

--- a/jit/frame.h
+++ b/jit/frame.h
@@ -1,8 +1,8 @@
 #include "emu/cpu.h"
 
 // keep in sync with asm
-#define JIT_RETURN_CACHE_SIZE 65536
-#define JIT_RETURN_CACHE_HASH(x) ((x) & 0xFFFF)
+#define JIT_RETURN_CACHE_SIZE 4096
+#define JIT_RETURN_CACHE_HASH(x) ((x) & 0xFFF0) >> 4)
 
 struct jit_frame {
     struct cpu_state cpu;

--- a/jit/frame.h
+++ b/jit/frame.h
@@ -10,5 +10,5 @@ struct jit_frame {
     addr_t value_addr;
     uint64_t value[2]; // buffer for crosspage crap
     struct jit_block *last_block;
-    long ret_cache[JIT_RETURN_CACHE_SIZE];
+    long ret_cache[JIT_RETURN_CACHE_SIZE]; // a map of ip to pointer-to-call-gadget-arguments
 };

--- a/jit/gadgets-aarch64/control.S
+++ b/jit/gadgets-aarch64/control.S
@@ -9,9 +9,8 @@
     ubfx w12, w8, 4, 12
     write_done 32, call
     add x13, _cpu, LOCAL_ret_cache
-    add x12, x13, x12, lsl 3
     add x14, _ip, 24
-    str x14, [x12]
+    str x14, [x13, x12, lsl 3]
     ldr _ip, [_ip, 8]
     b jit_ret_chain
     write_bullshit 32, call
@@ -25,9 +24,8 @@
     ubfx w12, w8, 4, 12
     write_done 32, call_indir
     add x13, _cpu, LOCAL_ret_cache
-    add x12, x13, x12, lsl 3
     add x14, _ip, 16
-    str x14, [x12]
+    str x14, [x13, x12, lsl 3]
     mov eip, _tmp
     b jit_ret
     write_bullshit 32, call_indir
@@ -56,8 +54,7 @@
     ldr _tmp, [_xaddr]
     ubfx w12, _tmp, 4, 12
     add x13, _cpu, LOCAL_ret_cache
-    add x12, x13, x12, lsl 3
-    ldr _ip, [x12]
+    ldr _ip, [x13, x12, lsl 3]
     cbz _ip, 1f
     gret
 1:

--- a/jit/gadgets-aarch64/control.S
+++ b/jit/gadgets-aarch64/control.S
@@ -6,7 +6,12 @@
     write_prep 32, call
     ldr w8, [_ip, 16]
     str w8, [_xaddr]
+    uxth w12, w8
     write_done 32, call
+    add x13, _cpu, LOCAL_ret_cache
+    add x12, x13, x12, lsl 3
+    add x14, _ip, 24
+    str x14, [x12]
     ldr _ip, [_ip, 8]
     b jit_ret_chain
     write_bullshit 32, call
@@ -17,17 +22,47 @@
     write_prep 32, call_indir
     ldr w8, [_ip, 8]
     str w8, [_xaddr]
+    uxth w12, w8
     write_done 32, call_indir
+    add x13, _cpu, LOCAL_ret_cache
+    add x12, x13, x12, lsl 3
+    add x14, _ip, 16
+    str x14, [x12]
     mov eip, _tmp
     b jit_ret
     write_bullshit 32, call_indir
+
+.gadget call_postamble
+    ldr w9, [_ip]
+    ldr x8, [_ip, 8]
+    cmp _tmp, w9
+    b.ne 1f
+    ldr _ip, [_ip, 16]
+    cmp _ip, 0
+    b.lt 1f
+    sub x8, _ip, JIT_BLOCK_code
+    str x8, [_cpu, LOCAL_last_block]
+    gret
+1:
+    str x8, [_cpu, LOCAL_last_block]
+    mov eip, _tmp
+    b jit_ret
 
 .gadget ret
     mov _addr, esp
     ldr w8, [_ip, 8]
     add esp, esp, w8
     read_prep 32, ret
-    ldr eip, [_xaddr]
+    ldr _tmp, [_xaddr]
+    uxth w12, _tmp
+    add x13, _cpu, LOCAL_ret_cache
+    add x12, x13, x12, lsl 3
+    ldr _ip, [x12]
+    cmp _ip, 0
+    b.eq 1f
+    gret
+1:
+    mov eip, _tmp
     b jit_ret
     read_bullshit 32, ret
 

--- a/jit/gadgets-aarch64/control.S
+++ b/jit/gadgets-aarch64/control.S
@@ -9,9 +9,8 @@
     ubfx w12, w8, 4, 12
     write_done 32, call
     add x13, _cpu, LOCAL_ret_cache
-    add x14, _ip, 24
-    str x14, [x13, x12, lsl 3]
-    ldr _ip, [_ip, 8]
+    str _ip, [x13, x12, lsl 3]
+    ldr _ip, [_ip, 32]
     b jit_ret_chain
     write_bullshit 32, call
 
@@ -19,32 +18,15 @@
     sub esp, esp, 4
     mov _addr, esp
     write_prep 32, call_indir
-    ldr w8, [_ip, 8]
+    ldr w8, [_ip, 16]
     str w8, [_xaddr]
     ubfx w12, w8, 4, 12
     write_done 32, call_indir
     add x13, _cpu, LOCAL_ret_cache
-    add x14, _ip, 16
-    str x14, [x13, x12, lsl 3]
+    str _ip, [x13, x12, lsl 3]
     mov eip, _tmp
     b jit_ret
     write_bullshit 32, call_indir
-
-.gadget call_postamble
-    ldr w9, [_ip]
-    ldr x8, [_ip, 8]
-    cmp _tmp, w9
-    b.ne 1f
-    ldr _ip, [_ip, 16]
-    cmp _ip, 0
-    b.lt 1f
-    sub x8, _ip, JIT_BLOCK_code
-    str x8, [_cpu, LOCAL_last_block]
-    gret
-1:
-    str x8, [_cpu, LOCAL_last_block]
-    mov eip, _tmp
-    b jit_ret
 
 .gadget ret
     mov _addr, esp
@@ -55,9 +37,21 @@
     ubfx w12, _tmp, 4, 12
     add x13, _cpu, LOCAL_ret_cache
     ldr _ip, [x13, x12, lsl 3]
-    cbz _ip, 1f
+    cbz _ip, 2f
+    ldr w9, [_ip, 16]
+    ldr x8, [_ip, 8]
+    cmp _tmp, w9
+    b.ne 1f
+    ldr _ip, [_ip, 24]
+    cmp _ip, 0
+    b.lt 1f
+    sub x8, _ip, JIT_BLOCK_code
+    str x8, [_cpu, LOCAL_last_block]
     gret
 1:
+    str x8, [_cpu, LOCAL_last_block]
+    // fallthrough
+2:
     mov eip, _tmp
     b jit_ret
     read_bullshit 32, ret

--- a/jit/gadgets-aarch64/control.S
+++ b/jit/gadgets-aarch64/control.S
@@ -6,7 +6,7 @@
     write_prep 32, call
     ldr w8, [_ip, 16]
     str w8, [_xaddr]
-    uxth w12, w8
+    ubfx w12, w8, 4, 12
     write_done 32, call
     add x13, _cpu, LOCAL_ret_cache
     add x12, x13, x12, lsl 3
@@ -22,7 +22,7 @@
     write_prep 32, call_indir
     ldr w8, [_ip, 8]
     str w8, [_xaddr]
-    uxth w12, w8
+    ubfx w12, w8, 4, 12
     write_done 32, call_indir
     add x13, _cpu, LOCAL_ret_cache
     add x12, x13, x12, lsl 3
@@ -54,12 +54,11 @@
     add esp, esp, w8
     read_prep 32, ret
     ldr _tmp, [_xaddr]
-    uxth w12, _tmp
+    ubfx w12, _tmp, 4, 12
     add x13, _cpu, LOCAL_ret_cache
     add x12, x13, x12, lsl 3
     ldr _ip, [x12]
-    cmp _ip, 0
-    b.eq 1f
+    cbz _ip, 1f
     gret
 1:
     mov eip, _tmp

--- a/jit/gadgets-aarch64/control.S
+++ b/jit/gadgets-aarch64/control.S
@@ -3,13 +3,16 @@
 .gadget call
     sub esp, esp, 4
     mov _addr, esp
+    // save return address
     write_prep 32, call
     ldr w8, [_ip, 16]
     str w8, [_xaddr]
+    // save ip-to-arguments to return cache
     ubfx w12, w8, 4, 12
-    write_done 32, call
+    write_done 32, call // clobbers w8
     add x13, _cpu, LOCAL_ret_cache
     str _ip, [x13, x12, lsl 3]
+    // jump to target
     ldr _ip, [_ip, 32]
     b jit_ret_chain
     write_bullshit 32, call
@@ -17,13 +20,16 @@
 .gadget call_indir
     sub esp, esp, 4
     mov _addr, esp
+    // save return address
     write_prep 32, call_indir
     ldr w8, [_ip, 16]
     str w8, [_xaddr]
+    // save ip-to-arguments to return cache
     ubfx w12, w8, 4, 12
-    write_done 32, call_indir
+    write_done 32, call_indir // clobbers w8
     add x13, _cpu, LOCAL_ret_cache
     str _ip, [x13, x12, lsl 3]
+    // jump to target
     mov eip, _tmp
     b jit_ret
     write_bullshit 32, call_indir
@@ -32,16 +38,21 @@
     mov _addr, esp
     ldr w8, [_ip, 8]
     add esp, esp, w8
+    // load return address and save to _tmp
     read_prep 32, ret
     ldr _tmp, [_xaddr]
+    // load saved ip in return cache
     ubfx w12, _tmp, 4, 12
     add x13, _cpu, LOCAL_ret_cache
     ldr _ip, [x13, x12, lsl 3]
+    // found?
     cbz _ip, 2f
+    // check if we jumped to the correct CALL instruction
     ldr w9, [_ip, 16]
     ldr x8, [_ip, 8]
     cmp _tmp, w9
     b.ne 1f
+    // good, now do return chaining, the logic is similar to `jit_ret_chain`
     ldr _ip, [_ip, 24]
     cmp _ip, 0
     b.lt 1f

--- a/jit/gadgets-x86_64/control.S
+++ b/jit/gadgets-x86_64/control.S
@@ -8,40 +8,22 @@
     movl %r14d, (%_addrq)
     shrw $4, %r14w
     movzwl %r14w, %r14d
-    leaq 24(%_ip), %r15
-    movq %r15, LOCAL_ret_cache(%_cpu, %r14, 8)
+    movq %_ip, LOCAL_ret_cache(%_cpu, %r14, 8)
     write_done 32, call
-    movq 8(%_ip), %_ip
+    movq 32(%_ip), %_ip
     jmp jit_ret_chain
 
 .gadget call_indir
     subl $4, %_esp
     movl %_esp, %_addr
     write_prep 32, call_indir
-    movl 8(%_ip), %r14d
+    movl 16(%_ip), %r14d
     movl %r14d, (%_addrq)
     shrw $4, %r14w
     movzwl %r14w, %r14d
-    leaq 16(%_ip), %r15
-    movq %r15, LOCAL_ret_cache(%_cpu, %r14, 8)
+    movq %_ip, LOCAL_ret_cache(%_cpu, %r14, 8)
     write_done 32, call_indir
     movl %_tmp, %_eip
-    jmp jit_ret
-
-.gadget call_postamble
-    movl (%_ip), %r14d
-    movq 8(%_ip), %r15
-    cmpl %r14d, %tmpd
-    jnz 1f
-    movq 16(%_ip), %_ip
-    btq $63, %_ip
-    jc 1f
-    leaq -JIT_BLOCK_code(%_ip), %r15
-    movq %r15, LOCAL_last_block(%_cpu)
-    gret
-1:
-    movq %r15, LOCAL_last_block(%_cpu)
-    movl %tmpd, %_eip
     jmp jit_ret
 
 .gadget ret
@@ -54,10 +36,22 @@
     movzwq %r14w, %r14
     movq LOCAL_ret_cache(%_cpu, %r14, 8), %_ip
     cmpq $0, %_ip
-    jz 1f
+    jz 2f
+    movl 16(%_ip), %r14d
+    movq 8(%_ip), %r15
+    cmpl %r14d, %tmpd
+    jnz 1f
+    movq 24(%_ip), %_ip
+    btq $63, %_ip
+    jc 1f
+    leaq -JIT_BLOCK_code(%_ip), %r15
+    movq %r15, LOCAL_last_block(%_cpu)
     gret
 1:
-    mov %tmp, %_ip
+    movq %r15, LOCAL_last_block(%_cpu)
+    // fallthrough
+2:
+    movl %tmpd, %_eip
     jmp jit_ret
 
 .gadget jmp_indir

--- a/jit/gadgets-x86_64/control.S
+++ b/jit/gadgets-x86_64/control.S
@@ -6,6 +6,10 @@
     write_prep 32, call
     movl 16(%_ip), %r14d
     movl %r14d, (%_addrq)
+    shrw $4, %r14w
+    movzwl %r14w, %r14d
+    leaq 24(%_ip), %r15
+    movq %r15, LOCAL_ret_cache(%_cpu, %r14, 8)
     write_done 32, call
     movq 8(%_ip), %_ip
     jmp jit_ret_chain
@@ -16,15 +20,44 @@
     write_prep 32, call_indir
     movl 8(%_ip), %r14d
     movl %r14d, (%_addrq)
+    shrw $4, %r14w
+    movzwl %r14w, %r14d
+    leaq 16(%_ip), %r15
+    movq %r15, LOCAL_ret_cache(%_cpu, %r14, 8)
     write_done 32, call_indir
     movl %_tmp, %_eip
+    jmp jit_ret
+
+.gadget call_postamble
+    movl (%_ip), %r14d
+    movq 8(%_ip), %r15
+    cmpl %r14d, %tmpd
+    jnz 1f
+    movq 16(%_ip), %_ip
+    btq $63, %_ip
+    jc 1f
+    leaq -JIT_BLOCK_code(%_ip), %r15
+    movq %r15, LOCAL_last_block(%_cpu)
+    gret
+1:
+    movq %r15, LOCAL_last_block(%_cpu)
+    movl %tmpd, %_eip
     jmp jit_ret
 
 .gadget ret
     movl %_esp, %_addr
     addl 8(%_ip), %_esp
     read_prep 32, ret
-    movl (%_addrq), %_eip
+    movl (%_addrq), %tmpd
+    movl %tmpd, %r14d
+    shrw $4, %r14w
+    movzwq %r14w, %r14
+    movq LOCAL_ret_cache(%_cpu, %r14, 8), %_ip
+    cmpq $0, %_ip
+    jz 1f
+    gret
+1:
+    mov %tmp, %_ip
     jmp jit_ret
 
 .gadget jmp_indir

--- a/jit/gadgets-x86_64/control.S
+++ b/jit/gadgets-x86_64/control.S
@@ -3,44 +3,55 @@
 .gadget call
     subl $4, %_esp
     movl %_esp, %_addr
+    // save return address
     write_prep 32, call
     movl 16(%_ip), %r14d
     movl %r14d, (%_addrq)
+    // save ip-to-arguments to return cache
     shrw $4, %r14w
     movzwl %r14w, %r14d
     movq %_ip, LOCAL_ret_cache(%_cpu, %r14, 8)
-    write_done 32, call
+    write_done 32, call // clobbers r14
+    // jump to target
     movq 32(%_ip), %_ip
     jmp jit_ret_chain
 
 .gadget call_indir
     subl $4, %_esp
     movl %_esp, %_addr
+    // save return address
     write_prep 32, call_indir
     movl 16(%_ip), %r14d
     movl %r14d, (%_addrq)
+    // save ip-to-arguments to return cache
     shrw $4, %r14w
     movzwl %r14w, %r14d
     movq %_ip, LOCAL_ret_cache(%_cpu, %r14, 8)
-    write_done 32, call_indir
+    write_done 32, call_indir // clobbers r14
+    // jump to target
     movl %_tmp, %_eip
     jmp jit_ret
 
 .gadget ret
     movl %_esp, %_addr
     addl 8(%_ip), %_esp
+    // load return address and save to _tmp
     read_prep 32, ret
     movl (%_addrq), %tmpd
     movl %tmpd, %r14d
+    // load saved ip in return cache
     shrw $4, %r14w
     movzwq %r14w, %r14
     movq LOCAL_ret_cache(%_cpu, %r14, 8), %_ip
+    // found?
     cmpq $0, %_ip
     jz 2f
+    // check if we jumped to the correct CALL instruction
     movl 16(%_ip), %r14d
     movq 8(%_ip), %r15
     cmpl %r14d, %tmpd
     jnz 1f
+    // good, now do return chaining, the logic is similar to `jit_ret_chain`
     movq 24(%_ip), %_ip
     btq $63, %_ip
     jc 1f

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -242,8 +242,8 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
 #define jcc(cc, to, else) gagg(jmp, cond_##cc, to, else); jump_ips(-2, -1); end_block = true
 #define J_REL(cc, off)  jcc(cc, fake_ip + off, fake_ip)
 #define JN_REL(cc, off) jcc(cc, fake_ip, fake_ip + off)
-#define CALL(loc) load(loc, OP_SIZE); ggg(call_indir, saved_ip, fake_ip); end_block = true
-#define CALL_REL(off) gggg(call, saved_ip, fake_ip + off, fake_ip); jump_ips(-2, 0); end_block = true
+#define CALL(loc) load(loc, OP_SIZE); ggg(call_indir, saved_ip, fake_ip); gggg(call_postamble, fake_ip, state->block, fake_ip); jump_ips(-1, 0); end_block = true
+#define CALL_REL(off) gggg(call, saved_ip, fake_ip + off, fake_ip); gggg(call_postamble, fake_ip, state->block, fake_ip); jump_ips(-6, -1); end_block = true
 #define RET_NEAR(imm) ggg(ret, saved_ip, 4 + imm); end_block = true
 #define INT(code) ggg(interrupt, (uint8_t) code, state->ip); end_block = true
 

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -49,7 +49,7 @@ void gen_end(struct gen_state *state) {
         list_init(&block->jumps_from_links[i]);
     }
     if (state->block_patch_ip != 0) {
-        block->code[state->block_patch_ip] = (unsigned long)block;
+        block->code[state->block_patch_ip] = (unsigned long) block;
     }
     if (block->addr != state->ip)
         block->end_addr = state->ip - 1;
@@ -249,6 +249,10 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
 #define J_REL(cc, off)  jcc(cc, fake_ip + off, fake_ip)
 #define JN_REL(cc, off) jcc(cc, fake_ip, fake_ip + off)
 
+// saved_ip: for use with page fault handler;
+// -1: will be patched to block address in gen_end();
+// fake_ip: the first one is used for verifying the cached ip in return cache is correct;
+// fake_ip: the second one is the return target, patchable by return chaining.
 #define CALL(loc) do { \
     load(loc, OP_SIZE); \
     ggggg(call_indir, saved_ip, -1, fake_ip, fake_ip); \
@@ -256,6 +260,8 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
     jump_ips(-1, 0); \
     end_block = true; \
 } while (0)
+// the first four arguments are the same with CALL,
+// the last one is the call target, patchable by return chaining.
 #define CALL_REL(off) do { \
     gggggg(call, saved_ip, -1, fake_ip, fake_ip, fake_ip + off); \
     state->block_patch_ip = state->size - 4; \

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -251,7 +251,7 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
 
 // saved_ip: for use with page fault handler;
 // -1: will be patched to block address in gen_end();
-// fake_ip: the first one is used for verifying the cached ip in return cache is correct;
+// fake_ip: the first one is the return address, used for saving to stack and verifying the cached ip in return cache is correct;
 // fake_ip: the second one is the return target, patchable by return chaining.
 #define CALL(loc) do { \
     load(loc, OP_SIZE); \

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -242,8 +242,8 @@ static inline bool gen_op(struct gen_state *state, gadget_t *gadgets, enum arg a
 #define jcc(cc, to, else) gagg(jmp, cond_##cc, to, else); jump_ips(-2, -1); end_block = true
 #define J_REL(cc, off)  jcc(cc, fake_ip + off, fake_ip)
 #define JN_REL(cc, off) jcc(cc, fake_ip, fake_ip + off)
-#define CALL(loc) load(loc, OP_SIZE); ggg(call_indir, saved_ip, fake_ip); gggg(call_postamble, fake_ip, state->block, fake_ip); jump_ips(-1, 0); end_block = true
-#define CALL_REL(off) gggg(call, saved_ip, fake_ip + off, fake_ip); gggg(call_postamble, fake_ip, state->block, fake_ip); jump_ips(-6, -1); end_block = true
+#define CALL(loc) load(loc, OP_SIZE); ggg(call_indir, saved_ip, fake_ip); gggg(call_postamble, fake_ip, -1, fake_ip); state->block->code[state->size - 2] = (long)state->block; jump_ips(-1, 0); end_block = true
+#define CALL_REL(off) gggg(call, saved_ip, fake_ip + off, fake_ip); gggg(call_postamble, fake_ip, -1, fake_ip); state->block->code[state->size - 2] = (long)state->block; jump_ips(-6, -1); end_block = true
 #define RET_NEAR(imm) ggg(ret, saved_ip, 4 + imm); end_block = true
 #define INT(code) ggg(interrupt, (uint8_t) code, state->ip); end_block = true
 

--- a/jit/gen.h
+++ b/jit/gen.h
@@ -10,6 +10,7 @@ struct gen_state {
     unsigned size;
     unsigned capacity;
     unsigned jump_ip[2];
+    unsigned block_patch_ip; // for call/call_indir gadgets
 };
 
 void gen_start(addr_t addr, struct gen_state *state);

--- a/jit/jit.c
+++ b/jit/jit.c
@@ -152,6 +152,8 @@ void cpu_run(struct cpu_state *cpu) {
     struct jit *jit = cpu->mem->jit;
     struct jit_block *cache[JIT_CACHE_SIZE] = {};
     struct jit_frame frame = {.cpu = *cpu};
+    for (size_t i = 0; i < JIT_RETURN_CACHE_SIZE; i++)
+        frame.ret_cache[i] = 0;
 
     int i = 0;
     read_wrlock(&cpu->mem->lock);

--- a/jit/jit.c
+++ b/jit/jit.c
@@ -207,6 +207,9 @@ void cpu_run(struct cpu_state *cpu) {
             tlb.mem = cpu->mem;
             if (cpu->mem->changes != changes) {
                 tlb_flush(&tlb);
+                // flush return cache
+                for (size_t i = 0; i < JIT_RETURN_CACHE_SIZE; i++)
+                    frame.ret_cache[i] = 0;
                 changes = cpu->mem->changes;
             }
             memset(cache, 0, sizeof(cache));

--- a/jit/offsets.c
+++ b/jit/offsets.c
@@ -48,6 +48,7 @@ void cpu() {
     OFFSET(LOCAL, jit_frame, value);
     OFFSET(LOCAL, jit_frame, value_addr);
     OFFSET(LOCAL, jit_frame, last_block);
+    OFFSET(LOCAL, jit_frame, ret_cache);
     OFFSET(CPU, cpu_state, segfault_addr);
     OFFSET(CPU, cpu_state, segfault_type);
     MACRO(MEM_READ);


### PR DESCRIPTION
This implements the return cache optimization for JIT mode.

The technical details of this optimization can be read at https://github.com/wishstudio/flinux/wiki/Dynamic-Binary-Translation#return-handling.

The implementation creates a new gadget named "call_postamble" and appends it after each call gadget. It checks whether the return address is correct and links to the actual successor code.

The actual performance improvement depends on application being run. I have observed run time reduction up to 15% on aarch64. No performance regression has been observed.