### PR TITLE
Upgrade Alpine to 3.11.2

### DIFF
--- a/iSH.xcodeproj/project.pbxproj
+++ b/iSH.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "curl -L http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/x86/alpine-minirootfs-3.10.0-x86.tar.gz -o $SRCROOT/alpine.tar.gz";
+			shellScript = "curl -L http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86/alpine-minirootfs-3.11.2-x86.tar.gz -o $SRCROOT/alpine.tar.gz";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/tests/e2e/e2e.bash
+++ b/tests/e2e/e2e.bash
@@ -8,7 +8,7 @@ VERBOSE=false
 YES_MODE=false
 TEST_PATTERN=""
 SUMMARY_LOG=./e2e_out/summary.txt
-ALPINE_IMAGE="http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/x86/alpine-minirootfs-3.10.0-x86.tar.gz"
+ALPINE_IMAGE="http://dl-cdn.alpinelinux.org/alpine/v3.11/releases/x86/alpine-minirootfs-3.11.2-x86.tar.gz"
 rm -f "$SUMMARY_LOG"
 
 while getopts "hvyf:e:" OPTION; do


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.11.0-released.html & https://alpinelinux.org/posts/Alpine-3.11.2-released.html

Due to a problem with Xcode and my 10 year old Macbook, I was unable to test this. I did, however, update Alpine manually on my iPhone and I didn't experience any errors.