### PR TITLE
Replace read lock with write lock in mm_copy

### DIFF
--- a/kernel/mmap.c
+++ b/kernel/mmap.c
@@ -25,9 +25,9 @@ struct mm *mm_copy(struct mm *mm) {
     new_mm->refcount = 1;
     mem_init(&new_mm->mem);
     fd_retain(new_mm->exefile);
-    read_wrlock(&mm->mem.lock);
+    write_wrlock(&mm->mem.lock);
     pt_copy_on_write(&mm->mem, &new_mm->mem, 0, MEM_PAGES);
-    read_wrunlock(&mm->mem.lock);
+    write_wrunlock(&mm->mem.lock);
     return new_mm;
 }
 


### PR DESCRIPTION
Fixes a thread sanitizer warning.