### PR TITLE
Add syscall 136 personality

### DIFF
--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -88,6 +88,7 @@ syscall_t syscall_table[] = {
     [125] = (syscall_t) sys_mprotect,
     [132] = (syscall_t) sys_getpgid,
     [133] = (syscall_t) sys_fchdir,
+    [136] = (syscall_t) sys_personality,
     [140] = (syscall_t) sys__llseek,
     [141] = (syscall_t) sys_getdents,
     [142] = (syscall_t) sys_select,

--- a/kernel/calls.h
+++ b/kernel/calls.h
@@ -190,7 +190,7 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size);
 dword_t sys_chdir(addr_t path_addr);
 dword_t sys_chroot(addr_t path_addr);
 dword_t sys_fchdir(fd_t f);
-dword_t sys_personality(dword_t pers);
+int_t sys_personality(dword_t pers);
 int task_set_thread_area(struct task *task, addr_t u_info);
 int sys_set_thread_area(addr_t u_info);
 int sys_set_tid_address(addr_t blahblahblah);

--- a/kernel/calls.h
+++ b/kernel/calls.h
@@ -190,6 +190,7 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size);
 dword_t sys_chdir(addr_t path_addr);
 dword_t sys_chroot(addr_t path_addr);
 dword_t sys_fchdir(fd_t f);
+dword_t sys_personality(dword_t pers);
 int task_set_thread_area(struct task *task, addr_t u_info);
 int sys_set_thread_area(addr_t u_info);
 int sys_set_tid_address(addr_t blahblahblah);

--- a/kernel/getset.c
+++ b/kernel/getset.c
@@ -170,3 +170,12 @@ int_t sys_capset(addr_t header_addr, addr_t data_addr) {
     STRACE("capset(%#x, %#x)", header_addr, data_addr);
     return 0;
 }
+
+// minimal version according to Linux sys/personality.h
+dword_t sys_personality(dword_t pers) {
+    if (pers == 0xffffffff)  // get personality, return default (Linux)
+        return 0x00000000;
+    if (pers == 0x00000000)  // set personality to Linux
+        return 0x00000000;
+    return -1;  // otherwise return error
+}

--- a/kernel/getset.c
+++ b/kernel/getset.c
@@ -177,5 +177,5 @@ dword_t sys_personality(dword_t pers) {
         return 0x00000000;
     if (pers == 0x00000000)  // set personality to Linux
         return 0x00000000;
-    return -1;  // otherwise return error
+    return _EINVAL;  // otherwise return error
 }

--- a/kernel/getset.c
+++ b/kernel/getset.c
@@ -172,7 +172,7 @@ int_t sys_capset(addr_t header_addr, addr_t data_addr) {
 }
 
 // minimal version according to Linux sys/personality.h
-dword_t sys_personality(dword_t pers) {
+int_t sys_personality(dword_t pers) {
     if (pers == 0xffffffff)  // get personality, return default (Linux)
         return 0x00000000;
     if (pers == 0x00000000)  // set personality to Linux


### PR DESCRIPTION
This provides the simple part of fixing #47, as GDB makes system call 136 `sys_personality` with arguments `0x0000` (set and return value for Linux) and `0xffffffffff` (get value). In any other case error code -1 is returned. See http://man7.org/linux/man-pages/man2/personality.2.html